### PR TITLE
Create ARGO templates

### DIFF
--- a/dataGraphs/thematics/dataset/graphs/datasetTemplate-ARGO.json
+++ b/dataGraphs/thematics/dataset/graphs/datasetTemplate-ARGO.json
@@ -1,0 +1,110 @@
+{
+    "@context": {
+        "@vocab": "https://schema.org/"
+    },
+    "@type": "Dataset",
+    "@id": "https://registry.org/permanentUrlToThisJsonDoc",
+    "name": "Argovis collection for Argo profiles",
+    "description": "An extended, free-text description of what's in the dataset, who created it, and other attributes (no Bfiles)",
+    "url": "https://argovis.colorado.edu/argo",
+    "license": "This work is licensed under a  Creative Commons Attribution (CC-BY) 4.0 License (link is best)",
+    "citation": [
+        "Argo citation in our About page (not what to cite for Argovis)",
+        "Citation to other work relevant to this dataset",
+        "Citation to other work relevant to this dataset"
+    ],
+    "creditText": "Cite this dataset as ... (Argovis specific citations: for more than one create array)",
+    "version": "2021-04-24T06:34:56.000Z (date Argovis was last updated for Argo)",
+    "keywords": [
+        "Keyword 1 (if defined words https://book.oceaninfohub.org/thematics/terms/list.html, see below @type)",
+        {
+            "@type": "DefinedTerm",
+            "identifier": "http://purl.org/dc/dcmitype/Image",
+            "inDefinedTermSet": "http://purl.org/dc/terms/DCMIType",
+            "termCode": "Image",
+            "name": "Image"
+        },
+        "Keyword 2",
+        "Keyword 3"
+    ],
+    "measurementTechnique": "Link to document/page that describes how an argo float works (create an array for more than one)",
+    "variableMeasured": [
+        {
+            "@type": "PropertyValue",
+            "name": "Name of a variable in the dataset",
+            "description": "Extended description of this variable"
+        },
+        {
+            "@type": "PropertyValue",
+            "name": "Name of a variable in the dataset",
+            "url": "http://ontology.org/uriToSemanticDescriptorOfThisVariable (if available on the web)",
+            "description": "Extended description of this variable? e.g. Long name and units (see https://book.oceaninfohub.org/thematics/variables/index.html)",
+            "unitCode": "units"
+        },
+        {
+            "@type": "PropertyValue",
+            "name": "SamplingDeviceApertureSurfaceArea",
+            "url": "http://ontology.org/uriToSemanticDescriptorOfThisVariable",
+            "description": "Extended description of this variable"
+        }
+    ],
+    "includedInDataCatalog": {
+        "@type": "DataCatalog",
+        "url": "https://urlOfDataCatalog.org (link to a page that lists all the datasets in Argovis, which would include the dataset decribed in this json-ld)"
+    },
+    "temporalCoverage": "2007/2007",
+    "distribution": {
+        "@type": "DataDownload",
+        "url": "add a URL to a page that shows people how to download chunks of the Argovis collection",
+        "contentUrl": "http://urlToDirectDownloadOfThisDataset.org/ (array of strings, each downloading data for a time chunk of the argo data that Argovis can manage without giving error)",
+        "encodingFormat": "text/csv",
+        "description": "Explain what each of the urls in contentUrl is (e.g. url to download data for each of the platforms? or chunks)"
+    },
+    "spatialCoverage": {
+        "@type": "Place",
+        "geo": {
+            "@type": "GeoShape",
+            "polygon": "142.014 10.161667,142.014 18.033833,147.997833 18.033833,147.997833 10.161667,142.014 10.161667 (using actual min/max long/lat in the dataset)"
+        },
+        "additionalProperty": {
+            "@type": "PropertyValue",
+            "propertyID": "http://dbpedia.org/resource/Spatial_reference_system",
+            "value": "http://www.w3.org/2003/01/geo/wgs84_pos#lat_long"
+        }
+    },
+    "isBasedOn": "link to Argo DAC (coriolis) as our collection is based on that",
+    "provider": {
+        "@type": "Organization",
+        "legalName": "University of Colorado Boulder",
+        "name": "Other Name of Organisation which generated the dataset",
+        "url": "https://organisationWebsite.org/"
+    },
+    "sdPublisher": {
+        "@type": "Organization",
+        "legalName": "University of Colorado Boulder",
+        "name": "Other Name of Organisation which generated the dataset",
+        "url": "https://organisationWebsite.org/"
+    },
+    "about": {
+        "@type": "Event",
+        "description": "Describe the event which is the subject of this dataset. For example, a cruise ID. e.g. Argo program",
+        "name": "Concise and descriptive name of the Event",
+        "potentialAction": {
+            "@type": "Action",
+            "name": "Concise but descriptive name of action that was part of an Event. For example, the name of a CTD cast",
+            "agent": [
+                "Name or permanent ID of person or thing that performed this action",
+                "Name or permanent ID of person or thing that performed this action",
+                "Name or permanent ID of person or thing that performed this action"
+            ],
+            "startTime": "2007-03-11T14:45UTC",
+            "endTime": "2007-03-11T15:42UTC",
+            "instrument": {
+                "@type": "Thing",
+                "name": "The name of the instrument used in the action. For example, the specific model of a CTD, a glider, a moored sensor",
+                "url": "http://ontology.org/uriToSemanticDescriptorOfThisInstrument",
+                "description": "Extended description of the sampling instrument"
+            }
+        }
+    }
+}

--- a/dataGraphs/thematics/dataset/graphs/datasetTemplate-ARGO.json
+++ b/dataGraphs/thematics/dataset/graphs/datasetTemplate-ARGO.json
@@ -68,8 +68,8 @@
         },
         "additionalProperty": {
             "@type": "PropertyValue",
-            "propertyID": "http://dbpedia.org/resource/Spatial_reference_system",
-            "value": "http://www.w3.org/2003/01/geo/wgs84_pos#lat_long"
+            "propertyID": "https://dbpedia.org/page/Spatial_reference_system",
+            "value": "https://www.w3.org/2003/01/geo/wgs84_pos"
         }
     },
     "isBasedOn": "link to Argo DAC (coriolis) as our collection is based on that",

--- a/dataGraphs/thematics/dataset/graphs/datasetTemplate-ARGO.json
+++ b/dataGraphs/thematics/dataset/graphs/datasetTemplate-ARGO.json
@@ -64,7 +64,7 @@
         "@type": "Place",
         "geo": {
             "@type": "GeoShape",
-            "polygon": "142.014 10.161667,142.014 18.033833,147.997833 18.033833,147.997833 10.161667,142.014 10.161667 (using actual min/max long/lat in the dataset)"
+            "polygon": "10.161667 142.014,18.033833 142.014,18.033833 147.997833,10.161667 147.997833,10.161667 142.014 (using actual min/max lat/long in the dataset)"
         },
         "additionalProperty": {
             "@type": "PropertyValue",

--- a/dataGraphs/thematics/vessels/graphs/vessel-ARGO-template.json
+++ b/dataGraphs/thematics/vessels/graphs/vessel-ARGO-template.json
@@ -1,0 +1,48 @@
+{
+    "@context": {
+        "@vocab": "https://schema.org/"
+    },
+    "@id": "https://example.org/id/X",
+    "@type": "Vehicle",
+    "name": "JOIDES Resolution",
+    "identifier": "4902112",
+    "model": "S2A",
+    "countryOfLastProcessing": "Angola",
+    "countryOfOrigin": {
+        "@type": "Country",
+        "name": "Fiji"
+    },
+    "additionalProperty": [
+        {
+            "@type": "PropertyValue",
+            "name": "data generated",
+            "propertyID": "data_type",
+            "value": "oceanicProfile",
+            "description": "This property describes the kind of data that this Argo float generates"
+        },
+        {
+            "@type": "PropertyValue",
+            "name": "associated data center",
+            "propertyID": "data_center",
+            "value": "AO",
+            "description": "This property describes ..."
+        },
+        {
+            "@type": "PropertyValue",
+            "name": "ArgoVIS identifier",
+            "propertyID": "_id",
+            "value": "4902112_m0",
+            "description": "This property describes the kind of data that this Argo float generates"
+        }
+    ],
+    "subjectOf": {
+        "@type": "DataDownload",
+        "name": "external-metadata.xml",
+        "description": "Metadata describing the vessel",
+        "encodingFormat": [
+            "application/xml",
+            "https://foo.org/ship01"
+        ],
+        "dateModified": "2019-06-12T14:44:15Z"
+    }
+}


### PR DESCRIPTION
- templates generated through the meeting:
  -  [datasetTemplate-ARGO.json](https://github.com/iodepo/odis-in/blob/argo-templates/dataGraphs/thematics/dataset/graphs/datasetTemplate-ARGO.json) 
  - [vessel-ARGO-template.json](https://github.com/iodepo/odis-in/blob/argo-templates/dataGraphs/thematics/vessels/graphs/vessel-ARGO-template.json)


- other notes from meeting:
  - use `additionalProperty` for other fields so that they are visible
  - include date when the data was updated
  - for `spatialCoverage` type, instead of `polygon` you can alternatively use `box` (bounding box coordinates) 
  - be sure to validate through: https://validator.schema.org/
  - see other templates for type [dataset](https://github.com/iodepo/odis-in/tree/master/dataGraphs/thematics/dataset/graphs)

- source metadata snippet for a Float:
  ```json
    [
      {
        "_id": "4902112_m0",
        "data_type": "oceanicProfile",
        "data_center": "AO",
        "instrument": "profiling_float",
        "pi_name": [
          "BRECK OWENS",
          " STEVEN JAYNE",
          " P.E. ROBBINS"
        ],
        "platform": "4902112",
        "platform_type": "S2A",
        "fleetmonitoring": "https://fleetmonitoring.euro-argo.eu/float/4902112",
        "oceanops": "https://www.ocean-ops.org/board/wa/Platform?ref=4902112",
        "positioning_system": "GPS",
        "wmo_inst_type": "854"
      }
  ]
  ```



related to https://github.com/iodepo/odis-arch/issues/404